### PR TITLE
bug fixes in Python frequency classes

### DIFF
--- a/python/sparkts/datetimeindex.py
+++ b/python/sparkts/datetimeindex.py
@@ -110,17 +110,21 @@ class HourFrequency(_Frequency):
 class BusinessDayFrequency(object):
     """
     A frequency that can be used for a uniform DateTimeIndex, where the period is given in
-    business days.
+    business days.  The first day of the business week is specified where Monday=1, Tuesday=2,
+    and so on.
     """
 
-    def __init__(self, bdays, sc):
-        self._jfreq = sc._jvm.com.cloudera.sparkts.BusinessDayFrequency(bdays)
+    def __init__(self, bdays, firstDayOfWeek, sc):
+        self._jfreq = sc._jvm.com.cloudera.sparkts.BusinessDayFrequency(bdays, firstDayOfWeek)
 
     def __eq__(self, other):
          return self._jfreq.equals(other._jfreq)
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    def days(self):
+        return self._jfreq.days()
 
 def uniform(start, end=None, periods=None, freq=None, sc=None):
     """

--- a/python/sparkts/datetimeindex.py
+++ b/python/sparkts/datetimeindex.py
@@ -105,7 +105,7 @@ class HourFrequency(_Frequency):
         self._jfreq = sc._jvm.com.cloudera.sparkts.HourFrequency(hours)
 
     def hours(self):
-        return self_jfreq.hours()
+        return self._jfreq.hours()
 
 class BusinessDayFrequency(object):
     """

--- a/python/sparkts/test/test_datetimeindex.py
+++ b/python/sparkts/test/test_datetimeindex.py
@@ -3,6 +3,10 @@ from sparkts.datetimeindex import *
 import pandas as pd
 
 class DateTimeIndexTestCase(PySparkTestCase):
+    def test_frequencies(self):
+        bd = BusinessDayFrequency(1, 1, self.sc)
+        self.assertEqual(bd.days(), 1)
+    
     def test_uniform(self):
         freq = DayFrequency(3, self.sc)
         self.assertEqual(freq.days(), 3)

--- a/python/sparkts/test/test_datetimeindex.py
+++ b/python/sparkts/test/test_datetimeindex.py
@@ -6,6 +6,9 @@ class DateTimeIndexTestCase(PySparkTestCase):
     def test_frequencies(self):
         bd = BusinessDayFrequency(1, 1, self.sc)
         self.assertEqual(bd.days(), 1)
+        
+        hf = HourFrequency(4, self.sc)
+        self.assertEqual(hf.hours(), 4)
     
     def test_uniform(self):
         freq = DayFrequency(3, self.sc)


### PR DESCRIPTION
* Fixed a syntax error in HourFrequency
* Added a "first day of week" parameter to BusinessDayFrequency. That parameter has a default in Scala, but the Python call to the Java constructor appears to require all parameters be set.