### PR TITLE
fix for issue 138

### DIFF
--- a/python/sparkts/models/ARIMA.py
+++ b/python/sparkts/models/ARIMA.py
@@ -104,7 +104,7 @@ def fit_model(p, d, q, ts, includeIntercept=True, method="css-cgd", userInitPara
     return ARIMAModel(jmodel=jmodel, sc=sc)
 
 class ARIMAModel(PyModel):
-    def __init__(self, p=0, d=0, q=0, coefficients=None, hasIntercept=False, jmodel=None, sc=None):
+    def __init__(self, p=0, d=0, q=0, coefficients=None, hasIntercept=True, jmodel=None, sc=None):
         assert sc != None, "Missing SparkContext"
 
         self._ctx = sc

--- a/python/sparkts/models/test/test_ARIMA.py
+++ b/python/sparkts/models/test/test_ARIMA.py
@@ -31,10 +31,6 @@ class FitARIMAModelTestCase(PySparkTestCase):
         self.assertAlmostEqual(ar, 0.55, delta=0.01)
         self.assertAlmostEqual(ma, 1.03, delta=0.01)
     
-    @unittest.skip("""
-    Test isn't working at the moment. model.sample(1000) results in a TooManyEvaluationsException
-    and sampling with fewer values results in a newModel that doesn't match the original model.
-    """)
     def test_remodel_sample_data(self):
         """
         Data sampled from a given model should result in a similar model if fit again.


### PR DESCRIPTION
The Python ARIMA model incorrectly had hasIntercept set to false, which was causing the unit test for re-fitting of sampled data to fail.