### PR TITLE
Python model unit test bug fixes

### DIFF
--- a/python/sparkts/models/test/test_AutoregressionX.py
+++ b/python/sparkts/models/test/test_AutoregressionX.py
@@ -13,7 +13,6 @@ X = np.random.normal(size=(nRows, nCols))
 intercept = np.random.normal() * 10
 
 class FitAutoregressionXModelTestCase(PySparkTestCase):
-    @unittest.skip("results don't match Scala right now")
     def test_predict(self):
         c = 0
         xCoeffs = [-1.136026484226831e-08, 8.637677568908233e-07,
@@ -28,4 +27,4 @@ class FitAutoregressionXModelTestCase(PySparkTestCase):
 
         results = arxModel.predict(y, x)
         self.assertEqual(len(results), 1)
-        self.assertAlmostEqual(results[0], 465, delta=0.0001)
+        self.assertAlmostEqual(results[0], y[0], delta=0.0001)

--- a/python/sparkts/models/test/test_RegressionARIMA.py
+++ b/python/sparkts/models/test/test_RegressionARIMA.py
@@ -7,7 +7,6 @@ from sparkts.models import RegressionARIMA
 from sparkts.models.RegressionARIMA import RegressionARIMAModel
 
 class FitRegressionARIMAModelTestCase(PySparkTestCase):
-    @unittest.skip("results don't match Scala right now")
     def test_cochrane_orcutt_empdata_with_maxiter(self):
         metal = [
             44.2, 44.3, 44.4, 43.4, 42.8, 44.3, 44.4, 44.8, 44.4, 43.1, 42.6, 42.4, 42.2,
@@ -17,7 +16,7 @@ class FitRegressionARIMAModelTestCase(PySparkTestCase):
         ]
         
         vendor = [
-            22.0, 317, 319, 323, 327, 328, 325, 326, 330, 334, 337, 341, 322, 318, 320,
+            322.0, 317, 319, 323, 327, 328, 325, 326, 330, 334, 337, 341, 322, 318, 320,
             326, 332, 334, 335, 336, 335, 338, 342, 348, 330, 326, 329, 337, 345, 350, 351, 354, 355, 357,
             362, 368, 348, 345, 349, 355, 362, 367, 366, 370, 371, 375, 380, 385, 361, 354, 357, 367, 376,
             381, 381, 383, 384, 387, 392, 396
@@ -26,7 +25,7 @@ class FitRegressionARIMAModelTestCase(PySparkTestCase):
         Y = np.array(metal)
         regressors = np.array(vendor).reshape(len(vendor), 1)
         
-        regARIMA = RegressionARIMA.fit_model(Y, regressors, method="cochrane-orcutt", optimizationArgs=[10], sc=self.sc)
+        regARIMA = RegressionARIMA.fit_model(Y, regressors, method="cochrane-orcutt", optimizationArgs=[1], sc=self.sc)
         beta = regARIMA.regressionCoeff
         self.assertAlmostEqual(beta[0], 28.918, delta=0.01)
         self.assertAlmostEqual(beta[1], 0.0479, delta=0.001)


### PR DESCRIPTION
* The AutoregressionX test was comparing to the wrong value from the source data.
* The RegressionARIMA test had a copy/paste error in the model source data.