### PR TITLE
Fix tsDiff vector in ADF test

### DIFF
--- a/src/main/scala/com/cloudera/sparkts/stats/TimeSeriesStatisticalTests.scala
+++ b/src/main/scala/com/cloudera/sparkts/stats/TimeSeriesStatisticalTests.scala
@@ -208,7 +208,11 @@ object TimeSeriesStatisticalTests {
    */
   def adftest(ts: Vector, maxLag: Int, regression: String = "c"): (Double, Double) = {
     val breezeTs = toBreeze(ts)
-    val tsDiff = UnivariateTimeSeries.differencesAtLag(ts, 1)
+    
+    // The vector that we get back from differencesAtLag preserves the first element so that so that the vector
+    // returned is size-preserving.  For ADF, we just want the differenced values, so we slice to get a vector
+    // that excludes the first element.
+    val tsDiff = new DenseVector(UnivariateTimeSeries.differencesAtLag(ts, 1).toArray.slice(1, ts.size))
     val lagMat = Lag.lagMatTrimBoth(tsDiff, maxLag, true)
     val nObs = lagMat.numRows
 


### PR DESCRIPTION
When comparing the ADF test stats and pvalues to statsmodel, they were slightly off.  I tracked the difference down to be a difference in the behavior of UnivariateTimeSeries.differencesAtLag vs numpy.diff (which statsmodel uses).  differencesAtLag wants to preserve the size of the vector, so it leaves the first n elements (depending on the lag) in the vector as the original value.  numpy's diff doesn't do this, and instead just returns a small list.  I modified the ADF code to remove the first element from the vector that we get back from differencesAtLag, so that all we have in tsDiff are the differences.